### PR TITLE
Add properties aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,10 +23,23 @@ spring:
       enabled: true
       prefixed: true
       paths: /mnt/secrets/this,/mnt/secrets/that,/mnt/secrets/other
+      aliases:
+        this.secret1: SECRET1
+        that.secret1: SECRET2
 ```
 By default both _enabled_ and _prefixed_ are true. This means that properties are
 loaded from the given paths (i.e. enabled) and the file parent directory is used 
 as prefix in the property name. 
+This means that the above configuration is exactly as this:
+```yaml
+spring:
+  cloud:
+    propertiesvolume:
+      paths: /mnt/secrets/this,/mnt/secrets/that,/mnt/secrets/other
+      aliases:
+        this.secret1: SECRET1
+        that.secret1: SECRET2
+```
 If a path is a directory all the contained files are loaded.
 For each file found:
 - the parent directory is the Azure Keyvault name
@@ -41,6 +54,28 @@ a property named as follows would be created:
 ```
 draft-store.primary-encryption-key
 ```
+
+Properties can also be aliased, so in the following declaration:
+```yaml
+spring:
+  cloud:
+    propertiesvolume:
+      paths: /mnt/secrets/draft-store/primary-encryption-key,/mnt/secrets/that
+      aliases:
+        draft-store.primary-encryption-key: SECRET1
+        that.secret1: SECRET2
+```
+the following 2 properties would have the same value:
+```
+draft-store.primary-encryption-key
+SECRET1
+```
+and also the following 2 properties would have the same value: 
+```
+that.secret1
+SECRET2
+```
+Please note that a single alias can be currently created for each property.
 
 If _prefixed_ is explicitly set to false (it defaults to true if omitted) then this is instead:
 ```yaml

--- a/build.gradle
+++ b/build.gradle
@@ -14,7 +14,7 @@ plugins {
 }
 
 group 'uk.gov.hmcts.reform'
-version '0.0.3'
+version '0.0.4'
 
 sourceCompatibility = 1.8
 targetCompatibility = 1.8

--- a/src/main/java/uk/gov/hmcts/reform/propertiesvolume/PropertiesvolumeConfigProperties.java
+++ b/src/main/java/uk/gov/hmcts/reform/propertiesvolume/PropertiesvolumeConfigProperties.java
@@ -4,6 +4,8 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Configuration values for properties (e.g. secrets) loaded from a keyvault flexvolume.
@@ -20,6 +22,8 @@ public class PropertiesvolumeConfigProperties {
     private String name;
 
     private List<String> paths = new LinkedList<>();
+
+    private Map<String, String> aliases = new ConcurrentHashMap<>();
 
     public boolean isEnabled() {
         return this.enabled;
@@ -51,6 +55,14 @@ public class PropertiesvolumeConfigProperties {
 
     public void setPaths(List<String> paths) {
         this.paths = paths;
+    }
+
+    public Map<String, String> getAliases() {
+        return aliases;
+    }
+
+    public void setAliases(Map<String, String> aliases) {
+        this.aliases = aliases;
     }
 
 }

--- a/src/main/java/uk/gov/hmcts/reform/propertiesvolume/PropertiesvolumePropertySource.java
+++ b/src/main/java/uk/gov/hmcts/reform/propertiesvolume/PropertiesvolumePropertySource.java
@@ -8,6 +8,7 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 
@@ -40,6 +41,7 @@ public class PropertiesvolumePropertySource extends MapPropertySource {
     private static Map<String, Object> getData(PropertiesvolumeConfigProperties config) {
         Map<String, Object> result = new ConcurrentHashMap<>();
         putPath(result, config.getPaths(), config.isPrefixed());
+        putAliases(result, config.getAliases());
         return result;
     }
 
@@ -57,6 +59,12 @@ public class PropertiesvolumePropertySource extends MapPropertySource {
                 .forEach(p -> readFile(p, result, prefixed));
         } catch (IOException e) {
             throw new PropertiesvolumeException("Error walking propertiesvolume files", e);
+        }
+    }
+
+    private static void putAliases(Map<String, ? super String> result, Map<String, String> aliases) {
+        if (aliases != null && !aliases.isEmpty()) {
+            aliases.forEach((k, v) -> result.computeIfAbsent(v, x -> Objects.toString(result.get(k), null)));
         }
     }
 

--- a/src/test/java/uk/gov/hmcts/reform/propertiesvolume/PropertiesvolumesFromFileSpringBootTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/propertiesvolume/PropertiesvolumesFromFileSpringBootTest.java
@@ -59,6 +59,9 @@ public class PropertiesvolumesFromFileSpringBootTest {
         this.webClient.get().uri("/api/hello?name=testapp.credtest").exchange().expectStatus().isOk()
             .expectBody().jsonPath(HelloController.HELLO_FIELD)
             .isEqualTo(String.format("Hello, %s-content!", "kv1"));
+        this.webClient.get().uri("/api/hello?name=testapp.credtestsame").exchange().expectStatus().isOk()
+            .expectBody().jsonPath(HelloController.HELLO_FIELD)
+            .isEqualTo(String.format("Hello, %s-content!", "kv1"));
     }
 
     @Test

--- a/src/test/java/uk/gov/hmcts/reform/propertiesvolume/PropertiesvolumesFromFileSpringBootTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/propertiesvolume/PropertiesvolumesFromFileSpringBootTest.java
@@ -62,6 +62,16 @@ public class PropertiesvolumesFromFileSpringBootTest {
     }
 
     @Test
+    public void shouldFindAllAliasedVolumeProperties() {
+        this.webClient.get().uri("/api/hello?name=" + "KV1_ALIAS").exchange().expectStatus().isOk()
+            .expectBody().jsonPath(HelloController.HELLO_FIELD)
+            .isEqualTo(String.format("Hello, kv1-content!"));
+        this.webClient.get().uri("/api/hello?name=" + "KV2_ALIAS").exchange().expectStatus().isOk()
+            .expectBody().jsonPath(HelloController.HELLO_FIELD)
+            .isEqualTo(String.format("Hello, kv2-content!"));
+    }
+
+    @Test
     public void shouldNotFindNonDeclaredVolumeProperties() {
         this.webClient.get().uri("/api/hello?name=kv4").exchange().expectStatus().isOk()
             .expectBody().jsonPath("content").isEqualTo("Hello, not found!");

--- a/src/test/resources/application.yaml
+++ b/src/test/resources/application.yaml
@@ -4,3 +4,4 @@ spring:
 
 testapp:
   credtest: ${kvcreds-test.kv1}
+  credtestsame: ${KV1_ALIAS}

--- a/src/test/resources/bootstrap.yaml
+++ b/src/test/resources/bootstrap.yaml
@@ -2,4 +2,7 @@ spring:
   cloud:
     propertiesvolume:
       paths: /tmp/Nhdt625dhwUyt/kvcreds-test
-
+      aliases:
+        kvcreds-test.kv1: KV1_ALIAS
+        kvcreds-test.kv2: KV2_ALIAS
+        


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/RPE-950


### Change description ###
A property can now have an alias. This is to make porting  applications easier as the current environment variables can be set as aliases when using propertyvolumes.


**Does this PR introduce a breaking change?** (check one with "x")

```
[ ] Yes
[x] No
```